### PR TITLE
Change `sendNotifiedTracking` visibility

### DIFF
--- a/nearit/src/main/java/it/near/sdk/recipes/background/NearItIntentService.java
+++ b/nearit/src/main/java/it/near/sdk/recipes/background/NearItIntentService.java
@@ -73,7 +73,7 @@ public class NearItIntentService extends IntentService {
                 .putExtras(intent.getExtras());
     }
 
-    private void sendNotifiedTracking(@NonNull Intent intent) {
+    protected void sendNotifiedTracking(@NonNull Intent intent) {
         String recipeId = intent.getStringExtra(NearItIntentConstants.RECIPE_ID);
         try {
             RecipesManager recipesManager = RecipesManager.getInstance();


### PR DESCRIPTION
Fix #12 : `sendNotifiedTracking` should have protected visibility to allow
subclasses to invoke it